### PR TITLE
kvm: svm: Do not intercept shadow stack MSRs for SNP guests

### DIFF
--- a/arch/x86/kvm/svm/sev.c
+++ b/arch/x86/kvm/svm/sev.c
@@ -4918,10 +4918,20 @@ void sev_vcpu_after_set_cpuid(struct vcpu_svm *svm)
 static void sev_snp_init_vmcb(struct vcpu_svm *svm)
 {
 	struct kvm_sev_info *sev = &to_kvm_svm(svm->vcpu.kvm)->sev_info;
+	struct kvm_vcpu *vcpu = &svm->vcpu;
 
 	/* V_NMI is not supported when Restricted Injection is enabled */
 	if (sev->vmsa_features[svm->vcpu.vmpl] & SVM_SEV_FEAT_RESTRICTED_INJECTION)
 		svm->vmcb->control.int_ctl &= ~V_NMI_ENABLE_MASK;
+
+	/* Shadow Stack MSRs */
+	set_msr_interception(vcpu, svm->msrpm, MSR_IA32_U_CET, 1, 1);
+	set_msr_interception(vcpu, svm->msrpm, MSR_IA32_S_CET, 1, 1);
+	set_msr_interception(vcpu, svm->msrpm, MSR_IA32_PL0_SSP, 1, 1);
+	set_msr_interception(vcpu, svm->msrpm, MSR_IA32_PL1_SSP, 1, 1);
+	set_msr_interception(vcpu, svm->msrpm, MSR_IA32_PL2_SSP, 1, 1);
+	set_msr_interception(vcpu, svm->msrpm, MSR_IA32_PL3_SSP, 1, 1);
+	set_msr_interception(vcpu, svm->msrpm, MSR_IA32_INT_SSP_TAB, 1, 1);
 }
 
 static void sev_es_init_vmcb(struct vcpu_svm *svm)

--- a/arch/x86/kvm/svm/svm.c
+++ b/arch/x86/kvm/svm/svm.c
@@ -142,6 +142,15 @@ static const struct svm_direct_access_msrs {
 	{ .index = X2APIC_MSR(APIC_TMICT),		.always = false },
 	{ .index = X2APIC_MSR(APIC_TMCCT),		.always = false },
 	{ .index = X2APIC_MSR(APIC_TDCR),		.always = false },
+
+	/* Shadow Stack MSRs - Not intercepted for SNP guests */
+	{ .index = MSR_IA32_U_CET,			.always = false },
+	{ .index = MSR_IA32_S_CET,			.always = false },
+	{ .index = MSR_IA32_PL0_SSP,			.always = false },
+	{ .index = MSR_IA32_PL1_SSP,			.always = false },
+	{ .index = MSR_IA32_PL2_SSP,			.always = false },
+	{ .index = MSR_IA32_PL3_SSP,			.always = false },
+	{ .index = MSR_IA32_INT_SSP_TAB,		.always = false },
 	{ .index = MSR_INVALID,				.always = false },
 };
 

--- a/arch/x86/kvm/svm/svm.h
+++ b/arch/x86/kvm/svm/svm.h
@@ -30,7 +30,7 @@
 #define	IOPM_SIZE PAGE_SIZE * 3
 #define	MSRPM_SIZE PAGE_SIZE * 2
 
-#define MAX_DIRECT_ACCESS_MSRS	48
+#define MAX_DIRECT_ACCESS_MSRS	55
 #define MSRPM_OFFSETS	32
 extern u32 msrpm_offsets[MSRPM_OFFSETS] __read_mostly;
 extern bool npt_enabled;


### PR DESCRIPTION
In SNP guests all shadow stack state is switched by hardware on vmrun/vmexit, so there is not need to intercept these MSRs, as it only breaks shadow stack support in this environment.