### PR TITLE
x86/sev: Ensure that RMP table fixups are reserved

### DIFF
--- a/arch/x86/virt/svm/sev.c
+++ b/arch/x86/virt/svm/sev.c
@@ -173,6 +173,8 @@ static void __init __snp_fixup_e820_tables(u64 pa)
 		e820__range_update(pa, PMD_SIZE, E820_TYPE_RAM, E820_TYPE_RESERVED);
 		e820__range_update_table(e820_table_kexec, pa, PMD_SIZE, E820_TYPE_RAM, E820_TYPE_RESERVED);
 		e820__range_update_table(e820_table_firmware, pa, PMD_SIZE, E820_TYPE_RAM, E820_TYPE_RESERVED);
+		if (!memblock_is_region_reserved(pa, PMD_SIZE))
+			memblock_reserve(pa, PMD_SIZE);
 	}
 }
 


### PR DESCRIPTION
RMPUPDATE fails sporadically while launching an SEV-SNP guest on Genoa servers. Cherry-pick an upstream fix to solve this issue. More details on the observed issue can be found [here](https://github.com/coconut-svsm/svsm/issues/668).