### PR TITLE
x86/sev: Add support for SVSM Reboot

### DIFF
--- a/arch/x86/coco/sev/core.c
+++ b/arch/x86/coco/sev/core.c
@@ -2251,6 +2251,7 @@ found_cc_info:
 
 static __head void svsm_setup(struct cc_blob_sev_info *cc_info)
 {
+	struct snp_secrets_page *secrets_page;
 	struct svsm_call call = {};
 	int ret;
 	u64 pa;
@@ -2288,6 +2289,25 @@ static __head void svsm_setup(struct cc_blob_sev_info *cc_info)
 
 	RIP_REL_REF(boot_svsm_caa) = (struct svsm_ca *)pa;
 	RIP_REL_REF(boot_svsm_caa_pa) = pa;
+
+	/*
+	 * SVSM Core Protocol v2 provides a mechanism to reboot a guest OS
+	 * Change the reboot mechanism to use the SVSM reboot.
+	 */
+	secrets_page = (struct snp_secrets_page *)cc_info->secrets_phys;
+	if (secrets_page->svsm_max_version >= 2)
+		RIP_REL_REF(reboot_type) = BOOT_SVSM;
+}
+
+void svsm_reboot(void)
+{
+	struct svsm_call call = {};
+
+	pr_emerg("Got to svsm_reboot\n");
+	call.caa = svsm_get_caa();
+	call.rax = SVSM_CORE_CALL(SVSM_CORE_REBOOT);
+	svsm_perform_call_protocol(&call);
+	pr_emerg("SVSM Reboot returned. It shouldn't have.\n");
 }
 
 bool __head snp_init(struct boot_params *bp)

--- a/arch/x86/include/asm/sev.h
+++ b/arch/x86/include/asm/sev.h
@@ -307,6 +307,7 @@ struct svsm_call {
 #define SVSM_CORE_PVALIDATE		1
 #define SVSM_CORE_CREATE_VCPU		2
 #define SVSM_CORE_DELETE_VCPU		3
+#define SVSM_CORE_REBOOT		8
 
 #define SVSM_ATTEST_CALL(x)		((1ULL << 32) | (x))
 #define SVSM_ATTEST_SERVICES		0
@@ -399,6 +400,7 @@ u64 snp_get_unsupported_features(u64 status);
 u64 sev_get_status(void);
 void sev_show_status(void);
 void snp_update_svsm_ca(void);
+void svsm_reboot(void);
 
 #else	/* !CONFIG_AMD_MEM_ENCRYPT */
 
@@ -435,6 +437,7 @@ static inline u64 snp_get_unsupported_features(u64 status) { return 0; }
 static inline u64 sev_get_status(void) { return 0; }
 static inline void sev_show_status(void) { }
 static inline void snp_update_svsm_ca(void) { }
+static inline void svsm_reboot(void) { }
 
 #endif	/* CONFIG_AMD_MEM_ENCRYPT */
 

--- a/arch/x86/kernel/reboot.c
+++ b/arch/x86/kernel/reboot.c
@@ -26,6 +26,7 @@
 #include <asm/cpu.h>
 #include <asm/nmi.h>
 #include <asm/smp.h>
+#include <asm/sev.h>
 
 #include <linux/ctype.h>
 #include <linux/mc146818rtc.h>
@@ -622,6 +623,13 @@ void __attribute__((weak)) mach_reboot_fixups(void)
  * can be triggered via the reboot= kernel boot option or
  * via quirks.
  *
+ * There is also the possibility that we are in a VM as an SVSM
+ * guest OS. We detect that at boot and set the reboot_type to
+ * BOOT_SVSM in that case. If SVSM Reboot fails, use the others as
+ * fallbacks, but ultimately, a Confidential Compute VM without
+ * SVSM probably can't be rebooted. It'll have to be shutdown via
+ * QEMU.
+ *
  * This means that this function can never return, it can misbehave
  * by not rebooting properly and hanging.
  */
@@ -710,6 +718,10 @@ static void native_machine_emergency_restart(void)
 
 			/* We're probably dead after this, but... */
 			reboot_type = BOOT_KBD;
+			break;
+		case BOOT_SVSM:
+			svsm_reboot();
+			reboot_type = BOOT_ACPI;
 			break;
 		}
 	}

--- a/include/linux/reboot.h
+++ b/include/linux/reboot.h
@@ -33,6 +33,7 @@ enum reboot_type {
 	BOOT_EFI	= 'e',
 	BOOT_CF9_FORCE	= 'p',
 	BOOT_CF9_SAFE	= 'q',
+	BOOT_SVSM	= 's',
 };
 extern enum reboot_type reboot_type;
 


### PR DESCRIPTION
Detect running with SVSM Core Protocol 2 and, if so, try using SVSM to do reboots.

At boot time, in svsm_setup(), examine SNP Secrets page to determine SVSM Core Protocol version 2 support.
If so, set reboot_type to BOOT_SVSM (an 's', following the convention of reboot_type being a single character.)

At reset time (e.g., 'sudo reboot'), in native_machine_emergency_restart(), if reboot_type is BOOT_SVSM, call svsm_reboot(). If that returns, fall back to ACPI reboot.
In svsm_reboot(), send the SVSM_CORE_REBOOT (8) message, which should not return.

As SVSM hasn't been updated to Core Protocol 2 yet, this code is dormant, but is required for testing SVSM_CORE_REBOOT.