### PR TITLE
KVM: SEV: set SNP AP as runnable on VPML run request

### DIFF
--- a/arch/x86/kvm/svm/sev.c
+++ b/arch/x86/kvm/svm/sev.c
@@ -4475,6 +4475,7 @@ static bool sev_snp_run_vmpl_wake(struct kvm_vcpu *vcpu, unsigned int vmpl)
 	if (!target_vcpu)
 		return false;
 
+	to_svm(target_vcpu)->sev_es.snp_ap_runnable = true;
 	kvm_set_mp_state(target_vcpu, KVM_MP_STATE_RUNNABLE);
 
 	return true;


### PR DESCRIPTION
Set `snp_ap_runnable` to true on a VMPL run request. This is needed because the destination vCPU may not have been run before, meaning that it will have a pending `KVM_REQ_UPDATE_PROTECTED_GUEST_STATE` request. This request will be honored by `vcpu_enter_guest()`, resetting the vCPU, and setting its `mp_state` in `sev_snp_init_protected_guest_state()` to `KVM_MP_STATE_UNINITIALIZED`, unless `snp_ap_runnable` is set to true.

This results in the vCPU being infinitely stuck in the main loop in `vcpu_run()`, as KVM will wait until an external signal sets the vCPU to a runnable state.

Fixes: 453450377b98 ("kvm/amd: Treat SEV_SNP_RUN_VMPL as INIT-SIPI")