### PR TITLE
Add support for OCP protocol

### DIFF
--- a/arch/x86/coco/sev/core.c
+++ b/arch/x86/coco/sev/core.c
@@ -1395,6 +1395,11 @@ static struct platform_device tpm_svsm_device = {
 	.id		= -1,
 };
 
+static struct platform_device ocp_svsm_device = {
+	.name		= "ocp-svsm",
+	.id		= -1,
+};
+
 static int __init snp_init_platform_device(void)
 {
 	if (!cc_platform_has(CC_ATTR_GUEST_SEV_SNP))
@@ -1405,6 +1410,10 @@ static int __init snp_init_platform_device(void)
 
 	if (snp_svsm_vtpm_probe() &&
 	    platform_device_register(&tpm_svsm_device))
+		return -ENODEV;
+
+	// TODO: add probe like above
+	if(platform_device_register(&ocp_svsm_device))
 		return -ENODEV;
 
 	pr_info("SNP guest platform devices initialized.\n");

--- a/arch/x86/coco/sev/svsm.c
+++ b/arch/x86/coco/sev/svsm.c
@@ -360,3 +360,93 @@ bool snp_svsm_vtpm_probe(void)
 	/* Check platform commands contains TPM_SEND_COMMAND - platform command 8 */
 	return call.rcx_out & BIT_ULL(8);
 }
+
+int snp_svsm_ocp_list_objects(u8 *buffer, u64 first_entry, u64 num_entries, u64 *entries_returned)
+{
+	struct svsm_call call = {};
+	int ret;
+
+	call.caa = svsm_get_caa();
+	call.rax = SVSM_OCP_CALL(SVSM_OCP_LIST_OBJECTS);
+	call.rcx = first_entry;
+	call.rdx = __pa(buffer);
+	call.r8 = num_entries;
+
+	ret = svsm_perform_call_protocol(&call);
+
+	if (ret < 0){
+		return ret;
+	}
+
+	*entries_returned = call.rcx_out;
+	return 0;
+}
+EXPORT_SYMBOL_GPL(snp_svsm_ocp_list_objects);
+
+int snp_svsm_ocp_list_object_sources(u8 *buffer, u32 object_entry, u32 first_entry, u64 num_entries, u32 *entries_returned)
+{
+	struct svsm_call call = {};
+	int ret;
+
+	call.caa = svsm_get_caa();
+	call.rax = SVSM_OCP_CALL(SVSM_OCP_LIST_OBJECT_SOURCES);
+	call.rcx = ((u64)object_entry << 32) | first_entry;
+	call.rdx = __pa(buffer);
+	call.r8 = num_entries;
+
+	ret = svsm_perform_call_protocol(&call);
+
+	if (ret < 0){
+		return ret;
+	}
+
+	*entries_returned = call.rcx_out;
+	return 0;
+}
+EXPORT_SYMBOL_GPL(snp_svsm_ocp_list_object_sources);
+
+int snp_svsm_ocp_read_source(u8 *buffer, u32 object_entry, u32 source_idx, u64 bytes_to_read, u64 offset, u64 *bytes_read)
+{
+	struct svsm_call call = {};
+	int ret;
+
+	call.caa = svsm_get_caa();
+	call.rax = SVSM_OCP_CALL(SVSM_OCP_READ);
+	call.rcx = ((u64)object_entry << 32) | source_idx;
+	call.rdx = __pa(buffer);
+	call.r8 = bytes_to_read;
+	call.r9 = offset;
+
+	ret = svsm_perform_call_protocol(&call);
+
+	if (ret < 0){
+		return ret;
+	}
+
+	*bytes_read = call.r8_out;
+	return 0;
+}
+EXPORT_SYMBOL_GPL(snp_svsm_ocp_read_source);
+
+int snp_svsm_ocp_write_source(u8 *buffer, u32 object_entry, u32 source_idx, u64 bytes_to_write, u64 offset, u64 *bytes_written)
+{
+	struct svsm_call call = {};
+	int ret;
+
+	call.caa = svsm_get_caa();
+	call.rax = SVSM_OCP_CALL(SVSM_OCP_WRITE);
+	call.rcx = ((u64)object_entry << 32) | source_idx;
+	call.rdx = __pa(buffer);
+	call.r8 = bytes_to_write;
+	call.r9 = offset;
+
+	ret = svsm_perform_call_protocol(&call);
+
+	if (ret < 0){
+		return ret;
+	}
+
+	*bytes_written = call.r8_out;
+	return 0;
+}
+EXPORT_SYMBOL_GPL(snp_svsm_ocp_write_source);

--- a/arch/x86/include/asm/sev.h
+++ b/arch/x86/include/asm/sev.h
@@ -435,6 +435,12 @@ struct svsm_call {
 #define SVSM_VTPM_QUERY			0
 #define SVSM_VTPM_CMD			1
 
+#define SVSM_OCP_CALL(x)		((5ULL << 32) | (x))
+#define SVSM_OCP_LIST_OBJECTS			0
+#define SVSM_OCP_LIST_OBJECT_SOURCES	1
+#define SVSM_OCP_READ					2
+#define SVSM_OCP_WRITE					3
+
 #ifdef CONFIG_AMD_MEM_ENCRYPT
 
 extern u8 snp_vmpl;
@@ -528,6 +534,10 @@ void snp_msg_free(struct snp_msg_desc *mdesc);
 int snp_send_guest_request(struct snp_msg_desc *mdesc, struct snp_guest_req *req);
 
 int snp_svsm_vtpm_send_command(u8 *buffer);
+int snp_svsm_ocp_list_objects(u8 *buffer, u64 first_entry, u64 num_entries, u64 *entries_returned);
+int snp_svsm_ocp_list_object_sources(u8 *buffer, u32 object_entry, u32 first_entry, u64 num_entries, u32 *entries_returned);
+int snp_svsm_ocp_read_source(u8 *buffer, u32 object_entry, u32 source_idx, u64 bytes_to_read, u64 offset, u64 *bytes_read);
+int snp_svsm_ocp_write_source(u8 *buffer, u32 object_entry, u32 source_idx, u64 bytes_to_write, u64 offset, u64 *bytes_written);
 
 void __init snp_secure_tsc_prepare(void);
 void __init snp_secure_tsc_init(void);
@@ -636,6 +646,10 @@ static inline void snp_msg_free(struct snp_msg_desc *mdesc) { }
 static inline int snp_send_guest_request(struct snp_msg_desc *mdesc,
 					 struct snp_guest_req *req) { return -ENODEV; }
 static inline int snp_svsm_vtpm_send_command(u8 *buffer) { return -ENODEV; }
+static int snp_svsm_ocp_list_objects(u8 *buffer, u64 first_entry, u64 num_entries, u64 *entries_returned) { return -ENODEV; }
+static int snp_svsm_ocp_list_object_sources(u8 *buffer, u32 object_entry, u32 first_entry, u64 num_entries, u32 *entries_returned) { return -ENODEV; }
+static int snp_svsm_ocp_read_source(u8 *buffer, u32 object_entry, u32 source_idx, u64 bytes_to_read, u64 offset, u64 *bytes_read) { return -ENODEV; }
+static int snp_svsm_ocp_write_source(u8 *buffer, u32 object_entry, u32 source_idx, u64 bytes_to_write, u64 offset, u64 *bytes_written) { return -ENODEV; }
 static inline void __init snp_secure_tsc_prepare(void) { }
 static inline void __init snp_secure_tsc_init(void) { }
 static inline void sev_evict_cache(void *va, int npages) {}

--- a/drivers/char/Kconfig
+++ b/drivers/char/Kconfig
@@ -397,4 +397,14 @@ config ADI
 	  and SSM (Silicon Secured Memory).  Intended consumers of this
 	  driver include crash and makedumpfile.
 
+config OCP_SVSM
+	tristate "SNP SVSM OCP interface"
+	depends on AMD_MEM_ENCRYPT
+	default m
+	help
+	  This is a driver for the AMD SVSM	OCP protocol that a SEV-SNP guest
+	  OS can use to retrieve or configure state information of the Secure
+	  VM Service Module (SVSM) in the guest context. To compile this
+	  driver, choose M here.
+
 endmenu

--- a/drivers/char/Makefile
+++ b/drivers/char/Makefile
@@ -43,3 +43,5 @@ obj-$(CONFIG_PS3_FLASH)		+= ps3flash.o
 obj-$(CONFIG_XILLYBUS_CLASS)	+= xillybus/
 obj-$(CONFIG_POWERNV_OP_PANEL)	+= powernv-op-panel.o
 obj-$(CONFIG_ADI)		+= adi.o
+
+obj-$(CONFIG_OCP_SVSM)		+= ocp_svsm.o

--- a/drivers/char/ocp_svsm.c
+++ b/drivers/char/ocp_svsm.c
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include <linux/module.h>
+#include <linux/version.h>
+#include <linux/kernel.h>
+#include <linux/types.h>
+#include <linux/kdev_t.h>
+#include <linux/fs.h>
+#include <linux/device.h>
+#include <linux/cdev.h>
+#include <linux/platform_device.h>
+
+#define OCP_CLASS "ocp"
+#define OCP_DEVICE "ocp"
+
+#define OCP_BUF_SIZE 4096
+
+static struct class *cl;
+
+struct ocp_dev {
+    struct device dev;
+    struct cdev cdev;
+    dev_t dev_num;
+
+    struct mutex buffer_mutex;
+
+    char *buffer;
+};
+
+static void ocp_dev_release(struct device *dev)
+{
+    struct ocp_dev *ocp = container_of(dev, struct ocp_dev, dev);
+
+    mutex_destroy(&ocp->buffer_mutex);
+
+    kfree(ocp->buffer);
+
+    kfree(ocp);
+    pr_info("released ocp driver dev");
+}
+
+static int ocp_open(struct inode *inode, struct file *file)
+{
+    struct ocp_dev *ocp;
+
+    ocp = container_of(inode->i_cdev, struct ocp_dev, cdev);
+    
+    file->private_data = ocp;
+
+    return 0;
+}
+
+static struct file_operations ocp_fops = {
+    .owner = THIS_MODULE,
+    .open = ocp_open,
+};
+
+static int __init ocp_svsm_probe(struct platform_device *pdev)
+{
+    int ret;
+    struct ocp_dev *ocp;
+
+    cl = class_create(OCP_CLASS);
+    if (IS_ERR(cl)) return PTR_ERR(cl);
+
+    ocp = kzalloc(sizeof(*ocp),GFP_KERNEL);
+    if(!ocp) {
+        class_destroy(cl);
+        return -ENOMEM;
+    }
+
+    ocp->buffer = kzalloc(OCP_BUF_SIZE,GFP_KERNEL);
+    if(!ocp->buffer) {
+        kfree(ocp);
+        class_destroy(cl);
+        return -ENOMEM;
+    }
+
+    mutex_init(&ocp->buffer_mutex);
+
+    ret = alloc_chrdev_region(&ocp->dev_num, 0, 1, OCP_DEVICE);
+    if(ret < 0) {
+        kfree(ocp->buffer);
+        kfree(ocp);
+        class_destroy(cl);
+        return ret;
+    }
+
+    device_initialize(&ocp->dev);
+    ocp->dev.class = cl;
+    ocp->dev.devt = ocp->dev_num;
+    ocp->dev.parent = &pdev->dev;
+    ocp->dev.release = ocp_dev_release;
+
+    ret = dev_set_name(&ocp->dev, OCP_DEVICE);
+    if (ret) {
+        unregister_chrdev_region(ocp->dev_num,1);
+        put_device(&ocp->dev);
+        class_destroy(cl);
+        return ret;
+    }
+    
+    cdev_init(&ocp->cdev, &ocp_fops);
+
+    platform_set_drvdata(pdev, ocp);
+        
+    ret = cdev_device_add(&ocp->cdev, &ocp->dev);
+
+    if (ret) {
+        unregister_chrdev_region(ocp->dev_num, 1);
+        put_device(&ocp->dev);
+        class_destroy(cl);
+        return ret;
+    }  
+
+    pr_info("successfully loaded ocp driver\n");
+    return 0;
+}
+
+static void __exit ocp_svsm_remove(struct platform_device *pdev)
+{
+    struct ocp_dev *ocp = platform_get_drvdata(pdev);
+
+    cdev_device_del(&ocp->cdev, &ocp->dev);
+
+    unregister_chrdev_region(ocp->dev_num, 1);
+
+    put_device(&ocp->dev);
+
+    class_destroy(cl);
+    pr_info("successfully removed ocp driver\n");
+}
+
+/*
+ * tpm_svsm_remove() lives in .exit.text. For drivers registered via
+ * module_platform_driver_probe() this is ok because they cannot get unbound
+ * at runtime. So mark the driver struct with __refdata to prevent modpost
+ * triggering a section mismatch warning.
+ */
+static struct platform_driver ocp_svsm_driver __refdata = {
+    .remove = __exit_p(ocp_svsm_remove),
+    .driver = {
+        .name = "ocp-svsm",
+    },
+};
+
+module_platform_driver_probe(ocp_svsm_driver, ocp_svsm_probe);
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Nicola Ramacciotti");
+MODULE_DESCRIPTION("SNP SVSM OCP Driver");


### PR DESCRIPTION
RFC PR for observability and configuration protocol

This is the linux-side handler.

It is still a work in progress. ~~For now it is only used to test `SVSM_OCP_LIST` request.~~
It contains the platform device and driver registration + all the ocp calls implementation.


~~This contains a  [test] commit with a module that can be loaded and will do a single call to SVSM_OCP_LIST during initialization. The parameter of this call can be changed based on a configuration parameter that can be specified when inserting the module. This can be inserted and removed multiple times.~~

see PR  https://github.com/coconut-svsm/svsm/pull/1138
